### PR TITLE
rotate arrow when navigation collapses

### DIFF
--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -147,6 +147,9 @@ const LinkList = styled(List)`
 const CollapseMenuItem = styled(MenuItemButton)`
   display: none;
 
+  transform: ${({ isCollapsed }) =>
+    isCollapsed ? "rotate(180deg)" : "rotate(0)"};
+
   @media (min-width: ${breakpoint("desktop")}) {
     display: flex;
   }


### PR DESCRIPTION
Add a style based on the prop to rotate the arrow when the navigation menu collapses.