### PR TITLE
Fix navigation support button

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -29,6 +29,14 @@ describe("Sidebar Navigation", () => {
       cy.get("nav")
         .contains("Settings")
         .should("have.attr", "href", "/dashboard/settings");
+
+      cy.get("nav")
+        .contains("Support")
+        .should(
+          "have.attr",
+          "href",
+          "mailto:support@prolog-app.com?subject=Subject Request:"
+        );
     });
 
     it("is collapsible", () => {
@@ -36,7 +44,7 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Collapse").click();
 
       // check that links still exist and are functionable
-      cy.get("nav").find("a").should("have.length", 5).eq(1).click();
+      cy.get("nav").find("a").should("have.length", 6).eq(1).click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
 
       // check that text is not rendered
@@ -80,7 +88,7 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("nav").find("a").should("have.length", 5);
+      cy.get("nav").find("a").should("have.length", 6);
 
       // Support button should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");

--- a/features/ui/sidebar-navigation/navigation-context.tsx
+++ b/features/ui/sidebar-navigation/navigation-context.tsx
@@ -9,7 +9,6 @@ const defaultContext = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   toggleSidebar: () => {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  triggerEmailClient: () => {},
 };
 
 export const NavigationContext = React.createContext(defaultContext);
@@ -26,10 +25,6 @@ export function NavigationProvider({
       value={{
         isSidebarCollapsed,
         toggleSidebar: () => setSidebarCollapsed((isCollapsed) => !isCollapsed),
-        triggerEmailClient: () => {
-          location.href =
-            "mailto:support@prolog-app.com?subject=Subject Request:";
-        },
       }}
     >
       {children}

--- a/features/ui/sidebar-navigation/navigation-context.tsx
+++ b/features/ui/sidebar-navigation/navigation-context.tsx
@@ -8,6 +8,8 @@ const defaultContext = {
   isSidebarCollapsed: false,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   toggleSidebar: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  triggerEmailClient: () => {},
 };
 
 export const NavigationContext = React.createContext(defaultContext);
@@ -24,6 +26,10 @@ export function NavigationProvider({
       value={{
         isSidebarCollapsed,
         toggleSidebar: () => setSidebarCollapsed((isCollapsed) => !isCollapsed),
+        triggerEmailClient: () => {
+          location.href =
+            "mailto:support@prolog-app.com?subject=Subject Request:";
+        },
       }}
     >
       {children}

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -162,7 +162,8 @@ const CollapseMenuItem = styled(MenuItemButton)`
 
 export function SidebarNavigation() {
   const router = useRouter();
-  const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
+  const { isSidebarCollapsed, toggleSidebar, triggerEmailClient } =
+    useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
   return (
     <Container isCollapsed={isSidebarCollapsed}>
@@ -202,7 +203,7 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() => triggerEmailClient()}
             />
             <CollapseMenuItem
               text="Collapse"

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -162,8 +162,7 @@ const CollapseMenuItem = styled(MenuItemButton)`
 
 export function SidebarNavigation() {
   const router = useRouter();
-  const { isSidebarCollapsed, toggleSidebar, triggerEmailClient } =
-    useContext(NavigationContext);
+  const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
   return (
     <Container isCollapsed={isSidebarCollapsed}>
@@ -199,11 +198,12 @@ export function SidebarNavigation() {
           </LinkList>
 
           <List>
-            <MenuItemButton
+            <MenuItemLink
+              href={"mailto:support@prolog-app.com?subject=Subject Request:"}
               text="Support"
               iconSrc="/icons/support.svg"
+              isActive={false}
               isCollapsed={isSidebarCollapsed}
-              onClick={() => triggerEmailClient()}
             />
             <CollapseMenuItem
               text="Collapse"


### PR DESCRIPTION
Learned Lesson: If it's difficult to test, then see if there is another way to achieve the solution. The problem here was a button was being used instead of an anchor link. With Cypress, it's very straightforward to test the href of an anchor link. However, trying to do this test on a button presents challenges. 

Going forward, try and remember to keep things simple. Just because it's React, that doesn't mean we need complex solutions.